### PR TITLE
Initial denormalization

### DIFF
--- a/farm_modus.services.yml
+++ b/farm_modus.services.yml
@@ -1,0 +1,5 @@
+services:
+  serializer.farm_modus.encoder.modus_json:
+    class: Drupal\farm_modus\Encoder\JsonEncoder
+    tags:
+      - { name: encoder, priority: 10, format: 'vnd.modus.v1.modus-result+json' }

--- a/farm_modus.services.yml
+++ b/farm_modus.services.yml
@@ -7,3 +7,8 @@ services:
     class: Drupal\farm_modus\Normalizer\ModusJsonWrapper
     tags:
       - { name: normalizer, priority: 10 }
+  serializer.farm_modus.normalizer.modus_soil_event:
+    class: Drupal\farm_modus\Normalizer\ModusEventSoil
+    tags:
+      - { name: normalizer, priority: 10 }
+    arguments: ['@typed_data_manager']

--- a/farm_modus.services.yml
+++ b/farm_modus.services.yml
@@ -3,3 +3,7 @@ services:
     class: Drupal\farm_modus\Encoder\JsonEncoder
     tags:
       - { name: encoder, priority: 10, format: 'vnd.modus.v1.modus-result+json' }
+  serializer.farm_modus.normalizer.modus_json:
+    class: Drupal\farm_modus\Normalizer\ModusJsonWrapper
+    tags:
+      - { name: normalizer, priority: 10 }

--- a/src/Encoder/JsonEncoder.php
+++ b/src/Encoder/JsonEncoder.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Drupal\farm_modus\Encoder;
+
+use Drupal\serialization\Encoder\JsonEncoder as SerializationJsonEncoder;
+
+/**
+ * Encodes modus json data.
+ */
+class JsonEncoder extends SerializationJsonEncoder {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $format = ['vnd.modus.v1.modus-result+json'];
+
+}

--- a/src/Normalizer/ModusEventBase.php
+++ b/src/Normalizer/ModusEventBase.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Drupal\farm_modus\Normalizer;
+
+use Drupal\Core\TypedData\TypedDataManagerInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+/**
+ * Normalized modus JSON into modus events.
+ *
+ * @todo Add helper functions for denormalizing lab and event metadata.
+ */
+abstract class ModusEventBase implements DenormalizerInterface {
+
+  /**
+   * The typed data manager.
+   *
+   * @var \Drupal\Core\TypedData\TypedDataManagerInterface
+   */
+  protected $typedDataManager;
+
+  /**
+   * Constructs a ModusEventbase object.
+   */
+  public function __construct(TypedDataManagerInterface $typed_data_manager) {
+    $this->typedDataManager = $typed_data_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function supportsDenormalization($data, $type, $format = NULL) {
+    return $type === static::TYPE && $format === static::FORMAT;
+  }
+
+}

--- a/src/Normalizer/ModusEventSoil.php
+++ b/src/Normalizer/ModusEventSoil.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Drupal\farm_modus\Normalizer;
+
+use Drupal\farm_modus\TypedData\ModusSlimBaseDefinition;
+use Drupal\farm_modus\TypedData\ModusSlimSoilDefinition;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+/**
+ * Normalized modus JSON into modus events.
+ */
+class ModusEventSoil extends ModusEventBase implements DenormalizerInterface {
+
+  /**
+   * The supported format.
+   */
+  const FORMAT = 'vnd.modus.v1.modus-result.soil+json';
+
+  /**
+   * The supported type to (de)normalize to.
+   */
+  const TYPE = ModusSlimBaseDefinition::class;
+
+  /**
+   * {@inheritDoc}
+   */
+  public function denormalize($data, $type, $format = NULL, array $context = []) {
+
+    // Build a modus slim object for each event.
+    $modus_slim = [
+      'samples' => [],
+    ];
+
+    // Skip if metadata is unavailable.
+    if (empty($data['LabMetaData']) || empty($data['EventMetaData'])) {
+      return;
+    }
+
+    // Get report file descriptions, indexed by ReportID (skip if empty).
+    $reports = [];
+    foreach ($data['LabMetaData']['Reports'] as $report) {
+      $reports[$report['ReportID']] = $report['FileDescription'] ?? '';
+    }
+
+    // Check for required event metadata.
+    // Date.
+    if (empty($data['EventMetaData']['EventDate'])) {
+      return;
+    }
+    $modus_slim['date'] = $data['EventMetaData']['EventDate'];
+
+    // Optional event metadata.
+    $modus_slim['id'] = $data['EventMetaData']['EventCode'] ?? NULL;
+
+    // Collect depths.
+    $depths = [];
+    foreach ($data['EventSamples']['Soil']['DepthRefs'] as $depth) {
+      $depths[$depth['DepthID']] = $depth;
+    }
+
+    // Build an array of samples.
+    $samples = [];
+    foreach ($data['EventSamples']['Soil']['SoilSamples'] as $sample) {
+
+      $sample_object = [
+        'type' => 'soil',
+        'id' => $sample['SampleMetaData']['SampleNumber'] ?? NULL,
+        'labid' => $sample['SampleMetaData']['ReportID'] ?? NULL,
+        'fmisid' => $sample['SampleMetaData']['FMISSampleID'] ?? NULL,
+        'geolocation' => $sample['SampleMetaData']['Geometry']['wkt'] ?? NULL,
+        'collection_date' => $sample['SampleMetaData']['CollectionDate'] ?? NULL,
+        'results' => [],
+      ];
+
+      // Iterate through the sample depths.
+      foreach ($sample['Depths'] as $depth_sample) {
+
+        $sample_object['depth'] = [
+          'id'     => $depth_sample['DepthID'],
+          'top'    => $depths[$depth_sample['DepthID']]['StartingDepth'],
+          'bottom' => $depths[$depth_sample['DepthID']]['EndingDepth'],
+          'units'  => $depths[$depth_sample['DepthID']]['DepthUnit'],
+        ];
+
+        // Iterate through the nutrient results and add a quantity for each
+        // (skip if empty).
+        if (empty($depth_sample['NutrientResults'])) {
+          continue;
+        }
+        foreach ($depth_sample['NutrientResults'] as $nutrient_result) {
+
+          // Round the value to 5 decimal places.
+          $value = round($nutrient_result['Value'], 5);
+
+          // Add a result.
+          $sample_object['results'][] = [
+            'analyte' => $nutrient_result['Element'],
+            'value'   => $value,
+            'units'   => $nutrient_result['ValueUnit'],
+            // @todo Add modus_test_id.
+          ];
+        }
+        $samples[] = $sample_object;
+      }
+    }
+
+    // Gather samples and create soil slim definition.
+    $modus_slim['samples'] = $samples;
+    return $this->typedDataManager->create(ModusSlimSoilDefinition::create(), $modus_slim);
+  }
+
+}

--- a/src/Normalizer/ModusJsonWrapper.php
+++ b/src/Normalizer/ModusJsonWrapper.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Drupal\farm_modus\Normalizer;
+
+use Drupal\farm_modus\TypedData\ModusSlimBaseDefinition;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\SerializerAwareInterface;
+use Symfony\Component\Serializer\SerializerAwareTrait;
+
+/**
+ * Normalized modus JSON into modus events.
+ */
+class ModusJsonWrapper implements DenormalizerInterface, SerializerAwareInterface {
+
+  use SerializerAwareTrait;
+
+  /**
+   * The supported format.
+   */
+  const FORMAT = 'vnd.modus.v1.modus-result+json';
+
+  /**
+   * The supported type to (de)normalize to.
+   */
+  const TYPE = ModusSlimBaseDefinition::class;
+
+  /**
+   * {@inheritDoc}
+   */
+  public function denormalize($data, $type, $format = NULL, array $context = []) {
+
+    // Build an array of events.
+    $events = [];
+    foreach ($data['Events'] ?? [] as $modus_event) {
+
+      // Defer to normalizer based on event type.
+      foreach ($modus_event['EventMetaData']['EventType'] ?? [] as $event_type_id => $included) {
+
+        // Only normalize event types that are included.
+        if (!$included) {
+          continue;
+        }
+
+        $event_format = strtolower($event_type_id);
+        $format = "vnd.modus.v1.modus-result.$event_format+json";
+
+        // Denormalize based on the format.
+        $events[] = $this->serializer->denormalize(
+          $modus_event,
+          ModusSlimBaseDefinition::class,
+          $format,
+        );
+      }
+    }
+    return $events;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function supportsDenormalization($data, $type, $format = NULL) {
+    return $type === static::TYPE && $format === static::FORMAT;
+  }
+
+}

--- a/src/Plugin/DataType/ModusResultNutrient.php
+++ b/src/Plugin/DataType/ModusResultNutrient.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Drupal\farm_modus\Plugin\DataType;
+
+use Drupal\Core\TypedData\Plugin\DataType\Map;
+
+/**
+ * Modus nutrient result data type.
+ *
+ * @DataType(
+ *   id = "modus_result:nutrient",
+ *   label = @Translation("Modus Result: Nutrient"),
+ *   definition_class = "\Drupal\farm_modus\TypedData\ModusResultNutrientDefinition"
+ * )
+ */
+class ModusResultNutrient extends Map {
+
+}

--- a/src/Plugin/DataType/ModusSampleSoil.php
+++ b/src/Plugin/DataType/ModusSampleSoil.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Drupal\farm_modus\Plugin\DataType;
+
+use Drupal\Core\TypedData\Plugin\DataType\Map;
+
+/**
+ * Modus soil sample data type.
+ *
+ * @DataType(
+ *   id = "modus_sample:soil",
+ *   label = @Translation("Modus Soil Sample"),
+ *   definition_class = "\Drupal\farm_modus\TypedData\ModusSampleSoilDefinition"
+ * )
+ */
+class ModusSampleSoil extends Map {
+
+}

--- a/src/Plugin/DataType/ModusSlimSoil.php
+++ b/src/Plugin/DataType/ModusSlimSoil.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Drupal\farm_modus\Plugin\DataType;
+
+use Drupal\Core\TypedData\Plugin\DataType\Map;
+
+/**
+ * Modus slim soil data type.
+ *
+ * @DataType(
+ *   id = "modus_slim:soil",
+ *   label = @Translation("Modus Slim: Soil"),
+ *   definition_class = "\Drupal\farm_modus\TypedData\ModusSlimSoilDefinition"
+ * )
+ */
+class ModusSlimSoil extends Map {
+
+}

--- a/src/TypedData/ModusResultNutrientDefinition.php
+++ b/src/TypedData/ModusResultNutrientDefinition.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Drupal\farm_modus\TypedData;
+
+use Drupal\Core\TypedData\ComplexDataDefinitionBase;
+use Drupal\Core\TypedData\DataDefinition;
+
+/**
+ * Data definition for Modus Nutient Result.
+ */
+class ModusResultNutrientDefinition extends ComplexDataDefinitionBase {
+
+  /**
+   * {@inheritDoc}
+   */
+  public static function create($type = 'modus_result:nutrient') {
+    $definition['type'] = $type;
+    return new self($definition);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getPropertyDefinitions() {
+    $properties = [];
+    $properties['analyte'] = DataDefinition::create('string');
+    $properties['value'] = DataDefinition::create('string');
+    $properties['units'] = DataDefinition::create('string');
+    $properties['modus_test_id'] = DataDefinition::create('string')
+      ->addConstraint('NotNull');
+
+    return $properties;
+  }
+
+}

--- a/src/TypedData/ModusSampleDefinition.php
+++ b/src/TypedData/ModusSampleDefinition.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Drupal\farm_modus\TypedData;
+
+use Drupal\Core\TypedData\ComplexDataDefinitionBase;
+use Drupal\Core\TypedData\DataDefinition;
+
+/**
+ * Base class for modus sample data definitions.
+ */
+abstract class ModusSampleDefinition extends ComplexDataDefinitionBase {
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getPropertyDefinitions() {
+    $properties = [];
+    $properties['id'] = DataDefinition::create('string');
+    $properties['labid'] = DataDefinition::create('string');
+    $properties['fmisid'] = DataDefinition::create('string');
+    $properties['collection_date'] = DataDefinition::create('datetime_iso8601');
+
+    // @todo Add geolocation type.
+    $properties['geolocation'] = DataDefinition::create('string');
+
+    return $properties;
+  }
+
+}

--- a/src/TypedData/ModusSampleSoilDefinition.php
+++ b/src/TypedData/ModusSampleSoilDefinition.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Drupal\farm_modus\TypedData;
+
+use Drupal\Core\TypedData\DataDefinition;
+use Drupal\Core\TypedData\ListDataDefinition;
+use Drupal\Core\TypedData\MapDataDefinition;
+
+/**
+ * Data definition for modus soil sample.
+ */
+class ModusSampleSoilDefinition extends ModusSampleDefinition {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create($type = 'modus_sample:soil') {
+    $definition['type'] = $type;
+    return new self($definition);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getPropertyDefinitions() {
+    $properties = parent::getPropertyDefinitions();
+
+    // Sample depth.
+    $properties['depth'] = MapDataDefinition::create()
+      ->setPropertyDefinition(
+        'id',
+        DataDefinition::create('string')
+      )
+      ->setPropertyDefinition(
+        'top',
+        DataDefinition::create('integer')
+      )
+      ->setPropertyDefinition(
+        'bottom',
+        DataDefinition::create('integer')
+      )
+      ->setPropertyDefinition(
+        'units',
+        DataDefinition::create('string')
+      );
+
+    // List of nutrient results.
+    $properties['results'] = ListDataDefinition::create('modus_result:nutrient')
+      ->setRequired(TRUE);
+
+    return $properties;
+  }
+
+}

--- a/src/TypedData/ModusSlimBaseDefinition.php
+++ b/src/TypedData/ModusSlimBaseDefinition.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Drupal\farm_modus\TypedData;
+
+use Drupal\Core\TypedData\ComplexDataDefinitionBase;
+use Drupal\Core\TypedData\DataDefinition;
+
+/**
+ * Base data definition for Modus slim.
+ *
+ * @see https://github.com/OADA/formats/blob/modus-slim/schemas/modus/slim/modus-result.schema.cts
+ */
+abstract class ModusSlimBaseDefinition extends ComplexDataDefinitionBase {
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getPropertyDefinitions() {
+    $properties = [];
+    $properties['id'] = DataDefinition::create('string')
+      ->setRequired(TRUE)
+      ->addConstraint('Length', [
+        'min' => 36,
+        'max' => 36,
+      ]);
+    $properties['date'] = DataDefinition::create('datetime_iso8601')
+      ->setRequired(TRUE);
+    $properties['type'] = DataDefinition::create('string')
+      ->setRequired(TRUE);
+
+    // @todo Add lab metadata.
+    $properties['lab'] = DataDefinition::create('string');
+
+    // @todo Add FMIS metadata.
+    $properties['fmis'] = DataDefinition::create('string');
+
+    return $properties;
+  }
+
+}

--- a/src/TypedData/ModusSlimSoilDefinition.php
+++ b/src/TypedData/ModusSlimSoilDefinition.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\farm_modus\TypedData;
+
+use Drupal\Core\TypedData\ListDataDefinition;
+
+/**
+ * Data definition for Modus slim soil.
+ */
+class ModusSlimSoilDefinition extends ModusSlimBaseDefinition {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create($type = 'modus_slim:soil') {
+    $definition['type'] = $type;
+    return new self($definition);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getPropertyDefinitions() {
+    $properties = parent::getPropertyDefinitions();
+
+    // Add list of soil samples.
+    $properties['samples'] = ListDataDefinition::create('modus_sample:soil')
+      ->setRequired(TRUE);
+
+    return $properties;
+  }
+
+}

--- a/tests/data/basic-modus-soil.json
+++ b/tests/data/basic-modus-soil.json
@@ -1,0 +1,90 @@
+{
+  "_type": "application/vnd.modus.v1.modus-result+json",
+  "Events": [
+    {
+      "EventMetaData": {
+        "EventCode": "ece3a2a8-4340-48b1-ae1f-d48d1f1e1692",
+        "EventDate": "2021-09-24",
+        "EventType": {
+          "Soil": true
+        }
+      },
+      "LabMetaData": {
+        "LabName": "A & L Great Lakes Laboratories",
+        "LabEventID": "F21267-0039",
+        "Contact": {
+          "Name": "A & L Great Lakes Laboratories",
+          "Phone": "260.483.4759",
+          "Address": "3505 Conestoga Dr.\nFort Wayne, IN 46808"
+        },
+        "ReceivedDate": "2021-09-24T00:00:00.000",
+        "ProcessedDate": "2021-09-28T00:00:00.000",
+        "ClientAccount": {
+          "AccountNumber": "30039",
+          "Company": "THE ANDERSONS FARM CTR - GPS",
+          "Name": "",
+          "City": "N MANCHESTER",
+          "State": "IN"
+        },
+        "Reports": [
+          {
+            "ReportID": "1",
+            "LabReportID": "F21271-0035"
+          }
+        ]
+      },
+      "FMISMetaData": {
+        "FMISEventID": "ece3a2a8-4340-48b1-ae1f-d48d1f1e1692",
+        "FMISProfile": {
+          "Grower": "CARL AULT",
+          "Farm": "ENYART EAST 50",
+          "Field": "50.1 AC",
+          "Sub-Field": ""
+        }
+      },
+      "EventSamples": {
+        "Soil": {
+          "DepthRefs": [
+            {
+              "DepthID": 1,
+              "Name": "Unknown Depth",
+              "StartingDepth": 0,
+              "EndingDepth": 8,
+              "ColumnDepth": 8,
+              "DepthUnit": "in"
+            }
+          ],
+          "SoilSamples": [
+            {
+              "SampleMetaData": {
+                "SampleNumber": "1",
+                "ReportID": "28051"
+              },
+              "Depths": [
+                {
+                  "DepthID": "1",
+                  "NutrientResults": [
+                    { "Element": "pH", "Value": 7.0, "ValueUnit": "none" },
+                    { "Element": "OM", "Value": 2.4, "ValueUnit": "%" },
+                    { "Element": "P", "Value": 34, "ValueUnit": "ppm" },
+                    { "Element": "K", "Value": 161, "ValueUnit": "ppm" },
+                    { "Element": "Ca", "Value": 1150, "ValueUnit": "ppm" },
+                    { "Element": "Mg", "Value": 240, "ValueUnit": "ppm" },
+                    { "Element": "CEC", "Value": 8.2, "ValueUnit": "meq/100g" },
+                    { "Element": "BS-Ca", "Value": 70.4, "ValueUnit": "%" },
+                    { "Element": "BS-Mg", "Value": 24.5, "ValueUnit": "%" },
+                    { "Element": "BS-K", "Value": 5.1, "ValueUnit": "%" },
+                    { "Element": "SO4-S", "Value": 7, "ValueUnit": "ppm" },
+                    { "Element": "Zn", "Value": 3.3, "ValueUnit": "ppm" },
+                    { "Element": "Mn", "Value": 46, "ValueUnit": "ppm" },
+                    { "Element": "B", "Value": 0.7, "ValueUnit": "ppm" }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/src/Kernel/ModusSerializationTest.php
+++ b/tests/src/Kernel/ModusSerializationTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Drupal\Tests\farm_modus\Kernel;
+
+use Drupal\farm_modus\TypedData\ModusSlimBaseDefinition;
+use Drupal\farm_modus\TypedData\ModusResultNutrientDefinition;
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Tests serialization of modus data.
+ */
+class ModusSerializationTest extends KernelTestBase {
+
+  /**
+   * The typed data manager.
+   *
+   * @var \Drupal\Core\TypedData\TypedDataManagerInterface
+   */
+  protected $typedDataManager;
+
+  /**
+   * The serializer service.
+   *
+   * @var \Symfony\Component\Serializer\SerializerInterface
+   */
+  protected $serializer;
+
+  /**
+   * Path to test data.
+   *
+   * @var string
+   */
+  protected string $dataPath;
+
+  /**
+   * {@inheritDoc}
+   */
+  protected static $modules = [
+    'farm_modus',
+    'serialization',
+  ];
+
+  /**
+   * {@inheritDoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->dataPath = $this->container->get('module_handler')
+      ->getModule('farm_modus')->getPath() . '/tests/data';
+
+    $this->typedDataManager = $this->container->get('typed_data_manager');
+    $this->serializer = $this->container->get('serializer');
+  }
+
+  /**
+   * Test deserializing modus v1 json to modus slim soil.
+   */
+  public function testDeserialization() {
+
+    // Test data.
+    $json = file_get_contents($this->dataPath . '/basic-modus-soil.json');
+    $format = 'vnd.modus.v1.modus-result+json';
+
+    /** @var \Drupal\farm_modus\Plugin\DataType\ModusSlimSoil[] $events */
+    $events = $this->serializer->deserialize($json, ModusSlimBaseDefinition::class, $format);
+    $this->assertCount(1, $events, 'One modus event is deserialized.');
+
+    // Test event metadata.
+    $event = reset($events);
+    $this->assertEquals('ece3a2a8-4340-48b1-ae1f-d48d1f1e1692', $event->get('id')->getValue());
+    $this->assertEquals('2021-09-24T00:00:00+00:00', $event->get('date')->getDateTime()->format('c'));
+
+    // @todo Test lab metadata.
+
+    // Test samples.
+    $samples = $event->get('samples');
+    $this->assertCount(1, $samples);
+    $sample = $samples->first();
+
+    // Test sample results.
+    $results = $sample->get('results');
+    $this->assertCount(14, $results);
+
+    // Test specific nutrient result.
+    $test = $this->typedDataManager->create(ModusResultNutrientDefinition::create(), [
+      'analyte' => 'P',
+      'value' => 34.0,
+      'units' => 'ppm',
+    ]);
+    $this->assertEquals($test->getValue(), $results[2]->getValue(), 'Has expected P result.');
+  }
+
+}


### PR DESCRIPTION
Adds initial denormalization infrastructure for going from `vnd.modus.v1.modus-result+json` json format to a typed data object that represents Soil samples in the "Modus slim" data format.

The process is like this:
1. Modus `JsonEncoder` simply turns the `vnd.modus.v1.modus-result+json` json format into an array. This is the same approach that Drupal core JSON:API uses for `application/vnd.api+json`
1. `ModusJsonWrapper` takes the entire Modus v1 json array and parses out each event type (eg: `Soil`), and attempts another deserialization from `vnd.modus.v1.modus-result.{EVENT_TYPE}+json` to `ModusSlimBaseDefinition` type data definition.
1. This PR includes one implementation, only deserializing `Soil` event data to the `ModusSlimSoil` data type. This Modus Soil Slim will have multiple Soil Samples (`ModusSampleSoil`), which each have multiple Results (`ModusResultNutrient`)
1. In the end, we have a `ModusSlimSoil` data type representing a batch of soil samples from one lab.

This Modus Slim typed data object can be used to further denormalize data into specific lab test log type either via a proper Normalizer service definition, or just by using the modus slim typed data object within a form. I'm not convinced we need a proper denomarlizer from json all the way to logs (does this create empty logs that are never saved? maybe that is OK?) This still TBD based on needs.

Eventually we will want a log *normalizer* that will go the opposite direction: lab test log -> modus slim data -> modus json.